### PR TITLE
Fix: Correct API endpoint URL for Telegram user registration

### DIFF
--- a/booking_bot/telegram_bot/handlers.py
+++ b/booking_bot/telegram_bot/handlers.py
@@ -32,7 +32,7 @@ def _get_profile(chat_id, first_name=None, last_name=None):
 
     try:
         # Ensure API_BASE is configured, e.g., http://localhost:8000/api/v1
-        api_url = f"{settings.API_BASE}/users/telegram-register-login/"
+        api_url = f"{settings.API_BASE}/telegram_auth/register_or_login/" # MODIFIED
         logger.info(f"Attempting to register/login user via API: {api_url} with payload: {payload}")
         response = requests.post(api_url, json=payload, timeout=10)
 


### PR DESCRIPTION
I've corrected the URL used by the Telegram bot in `handlers.py` to call the `TelegramRegisterLoginView`.

The API endpoint was changed from `/users/telegram-register-login/` to `/telegram_auth/register_or_login/` to match the actual URL configuration in `users/urls.py`.

This change is intended to resolve the 401 Unauthorized errors you encountered during the user registration/login process initiated by the Telegram bot.